### PR TITLE
AsyncResult

### DIFF
--- a/Result.Tests/AsyncResult/BindAsync.Tests.cs
+++ b/Result.Tests/AsyncResult/BindAsync.Tests.cs
@@ -1,0 +1,29 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_BindAsync_Tests
+    {
+        [Test]
+        public void Ok_Success()
+        {
+            var innerResult = Result.Success<int, string>(1);
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.BindAsync(i => i + 1).Unwrap();
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Ok_TwoFuncs()
+        {
+            var innerResult = Result.Success<int, string>(1);
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.BindAsync(i => i + 1, f => 0).Unwrap();
+            Assert.That(result, Is.EqualTo(2));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/BindToResultAsync.Tests.cs
+++ b/Result.Tests/AsyncResult/BindToResultAsync.Tests.cs
@@ -1,0 +1,29 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System.Threading;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_BindToResultAsync_Tests
+    {
+        [Test]
+        public void Ok_Success()
+        {
+            var innerResult = Result.Success<int, string>(1);
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.BindToResultAsync(i => Result.Success<int, string>(i + 1)).Unwrap();
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Ok_Failure()
+        {
+            var innerResult = Result.Failure<int, string>("Error");
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.BindToResultAsync(i => Result.Success<int, string>(i + 1)).UnwrapError();
+            Assert.That(result, Is.EqualTo("Error"));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/Create.Tests.cs
+++ b/Result.Tests/AsyncResult/Create.Tests.cs
@@ -1,0 +1,36 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_Create_Tests
+    {
+        [Test]
+        public void FromResult()
+        {
+            var result = Result.Success<int, string>(12);
+            var async = Lib.Result.AsyncResult.Create(result);
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+
+        [Test]
+        public void FromFunc()
+        {
+            var result = Result.Success<int, string>(12);
+            var func = (Func<Result<int, string>>)(() => result);
+            var async = Lib.Result.AsyncResult.Create(func);
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+
+        [Test]
+        public void FromTask()
+        {
+            var result = Result.Success<int, string>(12);
+            var task = Task.FromResult(result);
+            var async = Lib.Result.AsyncResult.Create(task);
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/Do.Tests.cs
+++ b/Result.Tests/AsyncResult/Do.Tests.cs
@@ -1,0 +1,29 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_Do_Tests
+    {
+        [Test]
+        public void Ok_Success()
+        {
+            var innerResult = Task.FromResult(Result.Success<int, string>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.Do(i => i + 1, e => 0);
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Ok_Failure()
+        {
+            var innerResult = Task.FromResult(Result.Failure<string, int>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = asyncResult.Do(i => 0, e => e + 1);
+            Assert.That(result, Is.EqualTo(2));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/DoAsync.Tests.cs
+++ b/Result.Tests/AsyncResult/DoAsync.Tests.cs
@@ -1,0 +1,49 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_DoAsync_Tests
+    {
+        [Test]
+        public async Task Ok_Success()
+        {
+            var innerResult = Task.FromResult(Result.Success<int, string>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = await asyncResult.DoAsync(i => i + 1, e => 0);
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task Ok_Failure()
+        {
+            var innerResult = Task.FromResult(Result.Failure<string, int>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+
+            var result = await asyncResult.DoAsync(i => 0, e => e + 1);
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task Ok_Success_Action()
+        {
+            var innerResult = Task.FromResult(Result.Success<int, string>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+            var result = -1;
+            await asyncResult.DoAsync(i => { result = i + 1; }, e => { result = 0; });
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task Ok_Failure_Action()
+        {
+            var innerResult = Task.FromResult(Result.Failure<string, int>(1));
+            var asyncResult = innerResult.ToAsyncResult();
+            var result = -1;
+            await asyncResult.DoAsync(i => { result = 0; }, e => { result = e + 1; });
+            Assert.That(result, Is.EqualTo(2));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/ToAsyncResult.Tests.cs
+++ b/Result.Tests/AsyncResult/ToAsyncResult.Tests.cs
@@ -1,0 +1,36 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_ToAsyncResult_Tests
+    {
+        [Test]
+        public void FromResult()
+        {
+            var result = Result.Success<int, string>(12);
+            var async = result.ToAsyncResult();
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+
+        [Test]
+        public void FromFunc()
+        {
+            var result = Result.Success<int, string>(12);
+            var func = (Func<Result<int, string>>)(() => result);
+            var async = func.ToAsyncResult();
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+
+        [Test]
+        public void FromTask()
+        {
+            var result = Result.Success<int, string>(12);
+            var task = Task.FromResult(result);
+            var async = task.ToAsyncResult();
+            Assert.That(result.Unwrap(), Is.EqualTo(async.Unwrap()));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/ToTask.Tests.cs
+++ b/Result.Tests/AsyncResult/ToTask.Tests.cs
@@ -1,0 +1,18 @@
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncResult_ToTask_Tests
+    {
+        [Test]
+        public async Task Ok()
+        {
+            var result = Result.Success<int, string>(12);
+            var async = result.ToAsyncResult();
+            var task = async.ToTask();
+            Assert.That(await task, Is.SameAs(result));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/UnwrapAsync.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapAsync.Tests.cs
@@ -1,0 +1,51 @@
+﻿namespace System1Group.Lib.Result.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Exceptions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OptionalResult_UnwrapAsync_Tests
+    {
+        [Test]
+        public async Task Success_Ok()
+        {
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var obj2 = await async.UnwrapAsync();
+
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public void Failure_Ok()
+        {
+            var error = "error message";
+            var error2 = "second error message";
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+
+            var e = Assert.ThrowsAsync<InvalidUnwrapException>(async () => await async.UnwrapAsync(error2));
+            Assert.That(e.Message, Is.EqualTo(error2));
+            Assert.That(e.Result, Is.EqualTo(async));
+            Assert.That(e.Item, Is.EqualTo(error));
+            Assert.That(e.FailedUnwrapType, Is.EqualTo(InvalidUnwrapException.UnwrapType.Success));
+        }
+
+        [Test]
+        public void Failure_Ok_WithoutMessage()
+        {
+            var error = "error message";
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+
+            var e = Assert.ThrowsAsync<InvalidUnwrapException>(async () => await async.UnwrapAsync());
+            Assert.That(e.Message, Does.StartWith("Tried to unwrap"));
+            Assert.That(e.Result, Is.EqualTo(async));
+            Assert.That(e.Item, Is.EqualTo(error));
+            Assert.That(e.FailedUnwrapType, Is.EqualTo(InvalidUnwrapException.UnwrapType.Success));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/UnwrapAsync.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapAsync.Tests.cs
@@ -1,12 +1,11 @@
-﻿namespace System1Group.Lib.Result.Tests
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
 {
-    using System;
     using System.Threading.Tasks;
     using Exceptions;
     using NUnit.Framework;
 
     [TestFixture]
-    public class OptionalResult_UnwrapAsync_Tests
+    public class AsyncResult_UnwrapAsync_Tests
     {
         [Test]
         public async Task Success_Ok()

--- a/Result.Tests/AsyncResult/UnwrapError.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapError.Tests.cs
@@ -1,0 +1,47 @@
+﻿namespace System1Group.Lib.Result.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Exceptions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OptionalResult_UnwrapErrorAsync_Tests
+    {
+        [Test]
+        public async Task Ok()
+        {
+            var error = "error";
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+            Assert.AreEqual(error, await async.UnwrapErrorAsync());
+        }
+
+        [Test]
+        public void Unwrap_Success_DefaultError()
+        {
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var e = Assert.ThrowsAsync<InvalidUnwrapException>(async () => await async.UnwrapErrorAsync());
+            Assert.That(e.Message, Does.StartWith("Tried to unwrap"));
+            Assert.That(e.Result, Is.EqualTo(async));
+            Assert.That(e.Item, Is.EqualTo(obj));
+            Assert.That(e.FailedUnwrapType, Is.EqualTo(InvalidUnwrapException.UnwrapType.Failure));
+        }
+
+        [Test]
+        public void Unwrap_Success_CustomError()
+        {
+            var error = "Error text";
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var e = Assert.ThrowsAsync<InvalidUnwrapException>(async () => await async.UnwrapErrorAsync(error));
+            Assert.That(e.Message, Is.EqualTo(error));
+            Assert.That(e.Result, Is.EqualTo(async));
+            Assert.That(e.Item, Is.EqualTo(obj));
+            Assert.That(e.FailedUnwrapType, Is.EqualTo(InvalidUnwrapException.UnwrapType.Failure));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/UnwrapError.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapError.Tests.cs
@@ -1,12 +1,11 @@
-﻿namespace System1Group.Lib.Result.Tests
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
 {
-    using System;
     using System.Threading.Tasks;
     using Exceptions;
     using NUnit.Framework;
 
     [TestFixture]
-    public class OptionalResult_UnwrapErrorAsync_Tests
+    public class AsyncResult_UnwrapErrorAsync_Tests
     {
         [Test]
         public async Task Ok()

--- a/Result.Tests/AsyncResult/UnwrapOr.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapOr.Tests.cs
@@ -1,0 +1,76 @@
+﻿namespace System1Group.Lib.Result.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OptionalResult_UnwrapOrAsync_Tests
+    {
+        [Test]
+        public async Task Success_Ok()
+        {
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var obj2 = await async.UnwrapOrAsync(new object());
+
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public async Task Failure_Ok()
+        {
+            var error = "error message";
+            var obj = new { field = "field" };
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+
+            var obj2 = await async.UnwrapOrAsync(obj);
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public async Task Success_WithFunc_Ok()
+        {
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var obj2 = await async.UnwrapOrAsync(() => new object());
+
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public async Task Failure_WithFunc_Ok()
+        {
+            var error = "error message";
+            var obj = new { field = "field" };
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+
+            var obj2 = await async.UnwrapOrAsync(() => obj);
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public async Task Success_WithArgumentFunc_Ok()
+        {
+            var obj = new { field = "field" };
+            var success = new Success<object, string>(obj);
+            var async = success.ToAsyncResult();
+            var obj2 = await async.UnwrapOrAsync(failure => new { field = failure });
+
+            Assert.That(obj, Is.EqualTo(obj2));
+        }
+
+        [Test]
+        public async Task Failure_WithArgumentFunc_Ok()
+        {
+            var error = "error message";
+            var failure = new Failure<object, string>(error);
+            var async = failure.ToAsyncResult();
+            var obj = await async.UnwrapOrAsync(err => err);
+            Assert.That(error, Is.EqualTo(obj));
+        }
+    }
+}

--- a/Result.Tests/AsyncResult/UnwrapOr.Tests.cs
+++ b/Result.Tests/AsyncResult/UnwrapOr.Tests.cs
@@ -1,10 +1,10 @@
-﻿namespace System1Group.Lib.Result.Tests
+﻿namespace System1Group.Lib.Result.Tests.AsyncResult
 {
     using System.Threading.Tasks;
     using NUnit.Framework;
 
     [TestFixture]
-    public class OptionalResult_UnwrapOrAsync_Tests
+    public class AsyncResult_UnwrapOrAsync_Tests
     {
         [Test]
         public async Task Success_Ok()

--- a/Result.Tests/System1Group.Lib.Result.Tests.csproj
+++ b/Result.Tests/System1Group.Lib.Result.Tests.csproj
@@ -4,9 +4,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CSharpRuleSet" Version="2.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Result\System1Group.Lib.Result.csproj" />

--- a/Result.Tests/TaskExtensionMethods/BindToTask.Tests.cs
+++ b/Result.Tests/TaskExtensionMethods/BindToTask.Tests.cs
@@ -1,0 +1,41 @@
+﻿namespace System1Group.Lib.Result.Tests.TaskExtensionMethods
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TaskExtensionMethods_Tests
+    {
+        [Test]
+        public async Task BindToTask()
+        {
+            var success = Result.Success<int, string>(12);
+            var bound = success.BindToTask(i => Task.FromResult(i + 1));
+            Assert.That((await bound).Unwrap(), Is.EqualTo(13));
+        }
+
+        [Test]
+        public async Task BindToTask_FromTask()
+        {
+            var success = Task.FromResult(Result.Success<int, string>(12));
+            var bound = success.BindToTask(i => Task.FromResult(i + 1));
+            Assert.That((await bound).Unwrap(), Is.EqualTo(13));
+        }
+
+        [Test]
+        public async Task BindToResultTask()
+        {
+            var success = Result.Success<int, string>(12);
+            var bound = success.BindToResultTask(i => Task.FromResult(Result.Success<int, string>(i + 1)));
+            Assert.That((await bound).Unwrap(), Is.EqualTo(13));
+        }
+
+        [Test]
+        public async Task BindToResultTask_FromTask()
+        {
+            var success = Task.FromResult(Result.Success<int, string>(12));
+            var bound = success.BindToResultTask(i => Task.FromResult(Result.Success<int, string>(i + 1)));
+            Assert.That((await bound).Unwrap(), Is.EqualTo(13));
+        }
+    }
+}

--- a/Result/AsyncResult.Static.cs
+++ b/Result/AsyncResult.Static.cs
@@ -1,0 +1,38 @@
+﻿namespace System1Group.Lib.Result
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public static class AsyncResult
+    {
+        public static AsyncResult<TSuccess, TFailure> Create<TSuccess, TFailure>(Result<TSuccess, TFailure> result)
+        {
+            return new AsyncResult<TSuccess, TFailure>(Task.FromResult(result));
+        }
+
+        public static AsyncResult<TSuccess, TFailure> Create<TSuccess, TFailure>(Task<Result<TSuccess, TFailure>> task)
+        {
+            return new AsyncResult<TSuccess, TFailure>(task);
+        }
+
+        public static AsyncResult<TSuccess, TFailure> Create<TSuccess, TFailure>(Func<Result<TSuccess, TFailure>> func)
+        {
+            return new AsyncResult<TSuccess, TFailure>(Task.Run(func));
+        }
+
+        public static AsyncResult<TSuccess, TFailure> ToAsyncResult<TSuccess, TFailure>(this Func<Result<TSuccess, TFailure>> func)
+        {
+            return Create(func);
+        }
+
+        public static AsyncResult<TSuccess, TFailure> ToAsyncResult<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> task)
+        {
+            return Create(task);
+        }
+
+        public static AsyncResult<TSuccess, TFailure> ToAsyncResult<TSuccess, TFailure>(this Result<TSuccess, TFailure> result)
+        {
+            return Create(Task.FromResult(result));
+        }
+    }
+}

--- a/Result/AsyncResult.cs
+++ b/Result/AsyncResult.cs
@@ -1,0 +1,136 @@
+﻿namespace System1Group.Lib.Result
+{
+    using System;
+    using System.Threading.Tasks;
+    using Attributes.ParameterTesting;
+    using CoreUtils;
+    using Exceptions;
+
+    public class AsyncResult<TSuccess, TFailure> : Result<TSuccess, TFailure>
+    {
+        private readonly Task<Result<TSuccess, TFailure>> task;
+
+        public AsyncResult(Task<Result<TSuccess, TFailure>> task)
+        {
+            Throw.IfNull(task, nameof(task));
+            this.task = task;
+        }
+
+        public override bool IsSuccess
+        {
+            get
+            {
+                this.task.Wait();
+                return this.task.Result.IsSuccess;
+            }
+        }
+
+        public override TReturn Do<TReturn>(Func<TSuccess, TReturn> onSuccess, Func<TFailure, TReturn> onFailure)
+        {
+            Throw.IfNull(onSuccess, nameof(onSuccess));
+            Throw.IfNull(onFailure, nameof(onFailure));
+            this.task.Wait();
+            return this.task.Result.Do(onSuccess, onFailure);
+        }
+
+        public async Task<TReturn> DoAsync<TReturn>(Func<TSuccess, TReturn> onSuccess, Func<TFailure, TReturn> onFailure)
+        {
+            Throw.IfNull(onSuccess, nameof(onSuccess));
+            Throw.IfNull(onFailure, nameof(onFailure));
+            var result = await this.task;
+            return result.Do(onSuccess, onFailure);
+        }
+
+        public async Task DoAsync(Action<TSuccess> onSuccess, Action<TFailure> onFailure)
+        {
+            Throw.IfNull(onSuccess, nameof(onSuccess));
+            Throw.IfNull(onFailure, nameof(onFailure));
+            var result = await this.task;
+            result.Do(onSuccess, onFailure);
+        }
+
+        public AsyncResult<TNew, TFailure> BindAsync<TNew>(Func<TSuccess, TNew> bindingFunc)
+        {
+            Throw.IfNull(bindingFunc, nameof(bindingFunc));
+            var result = SafeContinueWith(this.task, r => r.Bind(bindingFunc));
+            return new AsyncResult<TNew, TFailure>(result);
+        }
+
+        public virtual AsyncResult<TNewSuccess, TNewFailure> BindAsync<TNewSuccess, TNewFailure>(
+            Func<TSuccess, TNewSuccess> successBindingAction,
+            Func<TFailure, TNewFailure> failureBindingAction)
+        {
+            Throw.IfNull(successBindingAction, nameof(successBindingAction));
+            Throw.IfNull(failureBindingAction, nameof(failureBindingAction));
+            var result = SafeContinueWith(this.task, r => r.Bind(successBindingAction, failureBindingAction));
+            return new AsyncResult<TNewSuccess, TNewFailure>(result);
+        }
+
+        public AsyncResult<TNew, TFailure> BindToResultAsync<TNew>(Func<TSuccess, Result<TNew, TFailure>> bindingFunc)
+        {
+            Throw.IfNull(bindingFunc, nameof(bindingFunc));
+            var result = SafeContinueWith(this.task, r => r.BindToResult(bindingFunc));
+            return new AsyncResult<TNew, TFailure>(result);
+        }
+
+        public Task<TSuccess> UnwrapAsync([AllowedToBeNullEmptyOrWhitespace] string error = null)
+        {
+            return this.DoAsync(
+                item => item,
+                err => throw new InvalidUnwrapException(this, err, InvalidUnwrapException.UnwrapType.Success, error));
+        }
+
+        public virtual Task<TFailure> UnwrapErrorAsync([AllowedToBeNullEmptyOrWhitespace] string error = null)
+        {
+            return this.DoAsync(
+                item => throw new InvalidUnwrapException(this, item, InvalidUnwrapException.UnwrapType.Failure, error),
+                err => err);
+        }
+
+        public virtual Task<TSuccess> UnwrapOrAsync([AllowedToBeNull] TSuccess defaultItem)
+        {
+            return this.DoAsync(item => item, err => defaultItem);
+        }
+
+        public virtual Task<TSuccess> UnwrapOrAsync(Func<TSuccess> defaultItemCalculator)
+        {
+            Throw.IfNull(defaultItemCalculator, nameof(defaultItemCalculator));
+            return this.DoAsync(item => item, err => defaultItemCalculator());
+        }
+
+        public virtual Task<TSuccess> UnwrapOrAsync(Func<TFailure, TSuccess> defaultItemCalculator)
+        {
+            Throw.IfNull(defaultItemCalculator, nameof(defaultItemCalculator));
+            return this.DoAsync(item => item, defaultItemCalculator);
+        }
+
+        public Task<Result<TSuccess, TFailure>> ToTask()
+        {
+            return this.task;
+        }
+
+        private static async Task<TOut> SafeContinueWith<TIn, TOut>(Task<TIn> task, Func<TIn, TOut> func)
+        {
+            var res = await task;
+            return func(res);
+
+            // TODO: this is the previous implementation
+            // TODO: To run it in unit tests you need to add extra steps to set up a SynchronizationContext.
+            // TODO: There may be other edge case situations where this implemtation has issues... but it will be quicker.
+            // TODO: Might be worth investigating at some point how safe it is, how fast it is, and maybe re-introduce it.
+            /*
+            return task.ContinueWith(
+                t =>
+                {
+                    if (t.Exception != null)
+                    {
+                        throw t.Exception.InnerException ?? t.Exception;
+                    }
+
+                    return func(t.Result);
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+           */
+        }
+    }
+}

--- a/Result/Result.cs
+++ b/Result/Result.cs
@@ -88,7 +88,7 @@
         [ExcludeFromCodeCoverage]
         public virtual IGuardEntryPoint<TSuccess, TFailure, TOut> Guard<TOut>()
         {
-            return new ResultGuard<TSuccess, TFailure, TOut>(this); // Not very testable, but Result can't really be provided by IOC so it can't be
+            return new ResultGuard<TSuccess, TFailure, TOut>(this);
         }
     }
 }

--- a/Result/TaskExtensionMethods.cs
+++ b/Result/TaskExtensionMethods.cs
@@ -14,6 +14,16 @@
                 failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
         }
 
+        public static async Task<Result<TNew, TFailure>> BindToTask<TSuccess, TFailure, TNew>(
+            this Task<Result<TSuccess, TFailure>> task,
+            Func<TSuccess, Task<TNew>> bindingFunc)
+        {
+            var result = await task;
+            return await result.Do(
+                async success => Result.Success<TNew, TFailure>(await bindingFunc(success)),
+                failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
+        }
+
         public static Task<Result<TNew, TFailure>> BindToResultTask<TSuccess, TFailure, TNew>(
             this Result<TSuccess, TFailure> result,
             Func<TSuccess, Task<Result<TNew, TFailure>>> bindingFunc)
@@ -30,16 +40,6 @@
             var result = await task;
             return await result.Do(
                         bindingFunc,
-                        failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
-        }
-
-        public static async Task<Result<TNew, TFailure>> BindToTask<TSuccess, TFailure, TNew>(
-            this Task<Result<TSuccess, TFailure>> task,
-            Func<TSuccess, Task<TNew>> bindingFunc)
-        {
-            var result = await task;
-            return await result.Do(
-                        async success => Result.Success<TNew, TFailure>(await bindingFunc(success)),
                         failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
         }
     }

--- a/Result/TaskExtensionMethods.cs
+++ b/Result/TaskExtensionMethods.cs
@@ -1,0 +1,46 @@
+﻿namespace System1Group.Lib.Result
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public static class TaskExtensionMethods
+    {
+        public static Task<Result<TNew, TFailure>> BindToTask<TSuccess, TFailure, TNew>(
+            this Result<TSuccess, TFailure> result,
+            Func<TSuccess, Task<TNew>> bindingFunc)
+        {
+            return result.Do(
+                async success => Result.Success<TNew, TFailure>(await bindingFunc(success)),
+                failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
+        }
+
+        public static Task<Result<TNew, TFailure>> BindToResultTask<TSuccess, TFailure, TNew>(
+            this Result<TSuccess, TFailure> result,
+            Func<TSuccess, Task<Result<TNew, TFailure>>> bindingFunc)
+        {
+            return result.Do(
+                bindingFunc,
+                failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
+        }
+
+        public static async Task<Result<TNew, TFailure>> BindToResultTask<TSuccess, TFailure, TNew>(
+            this Task<Result<TSuccess, TFailure>> task,
+            Func<TSuccess, Task<Result<TNew, TFailure>>> bindingFunc)
+        {
+            var result = await task;
+            return await result.Do(
+                        bindingFunc,
+                        failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
+        }
+
+        public static async Task<Result<TNew, TFailure>> BindToTask<TSuccess, TFailure, TNew>(
+            this Task<Result<TSuccess, TFailure>> task,
+            Func<TSuccess, Task<TNew>> bindingFunc)
+        {
+            var result = await task;
+            return await result.Do(
+                        async success => Result.Success<TNew, TFailure>(await bindingFunc(success)),
+                        failure => Task.FromResult(Result.Failure<TNew, TFailure>(failure)));
+        }
+    }
+}


### PR DESCRIPTION
Adds those `Task<Result<T1, T2>>` extension methods and tests, as well as a `AsyncResult<T1, T2>` class that wraps a `Task<Result<T1, T2>>` and provides all the usual synchronous methods, and a few useful async equivalents,  such as `UnwrapAsync`, `BindAsync` and `DoAsync`